### PR TITLE
Add minimalist HTML page for headless server

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -3,6 +3,8 @@ import { Bus } from "../bus"
 import { describeRoute, generateSpecs, openAPISpecs } from "hono-openapi"
 import { Hono } from "hono"
 import { streamSSE } from "hono/streaming"
+import { readFileSync } from "fs"
+import { join } from "path"
 import { Session } from "../session"
 import { resolver, validator as zValidator } from "hono-openapi/zod"
 import { z } from "zod"
@@ -71,6 +73,15 @@ export namespace Server {
           log.info("response", {
             duration: Date.now() - start,
           })
+        }
+      })
+      .get("/", async (c) => {
+        try {
+          const htmlPath = join(import.meta.dir, "static", "index.html")
+          const html = readFileSync(htmlPath, "utf-8")
+          return c.html(html)
+        } catch (error) {
+          return c.text("opencode server is running", 200)
         }
       })
       .get(

--- a/packages/opencode/src/server/static/index.html
+++ b/packages/opencode/src/server/static/index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>opencode server</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: #0a0a0a;
+        color: #ffffff;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .container {
+        text-align: center;
+        max-width: 600px;
+        padding: 2rem;
+      }
+
+      .logo {
+        font-size: 3rem;
+        font-weight: 300;
+        margin-bottom: 1rem;
+        color: #00ff88;
+      }
+
+      .status {
+        font-size: 1.2rem;
+        margin-bottom: 2rem;
+        color: #888;
+      }
+
+      .status-indicator {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        background: #00ff88;
+        border-radius: 50%;
+        margin-right: 8px;
+        animation: pulse 2s infinite;
+      }
+
+      @keyframes pulse {
+        0% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.5;
+        }
+        100% {
+          opacity: 1;
+        }
+      }
+
+      .info {
+        background: #111;
+        border: 1px solid #333;
+        border-radius: 8px;
+        padding: 1.5rem;
+        margin-top: 2rem;
+      }
+
+      .info h3 {
+        color: #00ff88;
+        margin-bottom: 1rem;
+        font-size: 1.1rem;
+      }
+
+      .info p {
+        color: #ccc;
+        line-height: 1.6;
+        margin-bottom: 0.5rem;
+      }
+
+      .endpoint {
+        font-family: "Monaco", "Menlo", monospace;
+        background: #222;
+        padding: 0.5rem;
+        border-radius: 4px;
+        color: #00ff88;
+        margin: 0.5rem 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="logo">opencode</div>
+      <div class="status">
+        <span class="status-indicator"></span>
+        server running
+      </div>
+
+      <div class="info">
+        <h3>API Endpoints</h3>
+        <p>Your opencode server is running and ready to accept requests:</p>
+        <div class="endpoint">GET /doc - OpenAPI documentation</div>
+        <div class="endpoint">GET /event - Event stream</div>
+        <div class="endpoint">GET /app - Application info</div>
+        <div class="endpoint">POST /session - Create new session</div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
- Add static/index.html with dark theme and opencode branding
- Show server status with animated indicator
- Display available API endpoints for easy reference
- Add root route (/) to serve the HTML page with fallback to plain text
- Maintains all existing API functionality

🤖 Generated with [opencode](https://opencode.ai)